### PR TITLE
Start to support logins without cookies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.2.1.RELEASE</spring.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
     </properties>
 
     <name>Spring Security LTI 1.3</name>
@@ -112,6 +112,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.29</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
@@ -122,6 +122,12 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
         if (ltiMessageHint != null) {
             additionalParameters.put("lti_message_hint", ltiMessageHint);
         }
+        
+        // These are additional parameters that we want to keep but they aren't part of the message
+        Map<String, Object> attributes = new HashMap<>();
+        // This is so that we can check the first and last requests of the login are from
+        // the same IP address.
+        attributes.put(StateAuthorizationRequestRepository.REMOTE_IP, request.getRemoteAddr());
 
         OAuth2AuthorizationRequest authorizationRequest = builder
                 .clientId(clientRegistration.getClientId())
@@ -130,6 +136,7 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
                 .scopes(clientRegistration.getScopes())
                 .state(this.stateGenerator.generateKey())
                 .additionalParameters(additionalParameters)
+                .attributes(attributes)
                 .build();
 
         return authorizationRequest;

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRequestRepository.java
@@ -1,0 +1,104 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.Assert;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.function.BiConsumer;
+
+/**
+ * This store uses the state value in the initial request to lookup the request when the client
+ * returns. Normally this would expose the login to a CSRF attack but we also check that the
+ * remote IP address is the same in an attempt to limit this.
+ */
+public final class StateAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    /**
+     * The key we use to store the remote IP in attributes.
+     */
+    public static final String REMOTE_IP = "remote_ip";
+    
+    // The cache of request in flight
+    private final Cache<String, OAuth2AuthorizationRequest> store;
+
+    // Should we limit the login to a single IP address.
+    // This may cause problems when users are on mobile devices and subsequent requests don't use the same IP address.
+    private boolean limitIpAddress = true;
+
+    // The handler to be called when an IP address mismatch is detected, by default this doesn't do anything.
+    // It is expected that this will do something like logging of the mismatch.
+    private BiConsumer<String, String> ipMismatchHandler = (a,b) -> {};
+
+    public StateAuthorizationRequestRepository(Duration duration) {
+        store = CacheBuilder.newBuilder()
+                .expireAfterAccess(duration)
+                .build();
+    }
+
+    public void setLimitIpAddress(boolean limitIpAddress) {
+        this.limitIpAddress = limitIpAddress;
+    }
+
+    public void setIpMismatchHandler(BiConsumer<String, String> ipMismatchHandler) {
+        this.ipMismatchHandler = ipMismatchHandler;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Assert.notNull(request, "request cannot be null");
+        String stateParameter = request.getParameter(OAuth2ParameterNames.STATE);
+        if (stateParameter == null) {
+            return null;
+        }
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = store.getIfPresent(stateParameter);
+        if (oAuth2AuthorizationRequest != null) {
+            // The IP address from the initial request
+            String initialIp = oAuth2AuthorizationRequest.getAttribute(REMOTE_IP);
+            if (initialIp != null) {
+                String requestIp = request.getRemoteAddr();
+                if (!initialIp.equals(request.getRemoteAddr())) {
+                    // Even if we aren't limiting IP address we call the consumer.
+                    ipMismatchHandler.accept(initialIp, requestIp);
+                    if (limitIpAddress) {
+                        return null;
+                    }
+                }
+            }
+        } 
+        return oAuth2AuthorizationRequest;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        Assert.notNull(request, "request cannot be null");
+        Assert.notNull(response, "response cannot be null");
+        if (authorizationRequest == null) {
+            this.removeAuthorizationRequest(request, response);
+            return;
+        }
+        String state = authorizationRequest.getState();
+        Assert.hasText(state, "authorizationRequest.state cannot be empty");
+        store.put(state, authorizationRequest);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return removeAuthorizationRequest(request, null);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        if (authorizationRequest != null) {
+            String stateParameter = request.getParameter(OAuth2ParameterNames.STATE);
+            store.invalidate(stateParameter);
+        }
+        return authorizationRequest;
+    }
+}

--- a/src/test/java/uk/ac/ox/ctl/lti13/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/Lti13Step3Test.java
@@ -13,7 +13,6 @@ import com.nimbusds.jwt.SignedJWT;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -102,12 +101,14 @@ public class Lti13Step3Test {
                 }
 
                 @Override
-                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider) {
+                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
                     // This is so that we can put a fake original request into the repository so that the state between
                     // the fake request and out test request will match.
-                    OAuth2LoginAuthenticationFilter oAuth2LoginAuthenticationFilter = super.configureLoginFilter(clientRegistrationRepository, oidcLaunchFlowAuthenticationProvider);
+                    OAuth2LoginAuthenticationFilter oAuth2LoginAuthenticationFilter = super.configureLoginFilter(clientRegistrationRepository, oidcLaunchFlowAuthenticationProvider, authorizationRequestRepository);
                     // Set a custom request repository
-                    oAuth2LoginAuthenticationFilter.setAuthorizationRequestRepository(authorizationRequestRepository);
+                    oAuth2LoginAuthenticationFilter.setAuthorizationRequestRepository(
+                            CustomLti13Configuration.this.authorizationRequestRepository
+                    );
                     return oAuth2LoginAuthenticationFilter;
                 }
             };


### PR DESCRIPTION
This uses the state parameter to link up an original request with the final one. This means there doesn't need to be a cookie used between the first and last request. However this does expose a potential CSRF attack as the last request doesn't need any state on the client.

There's basic support to mitigate this with an IP restriction that requires that the first and last request are made from the same IP address, however this isn't ideal as it's perfectly possible for requests to come from different IPs (for example carrier grade NAT, mobile networks where access it temporarily lost, other proxy solutions).

At the moment when configuring LTI 1.3 you can choose to use the session based support or the state parameter.

Fixes: #2