### PR TITLE
Add tests specifically for stateless config

### DIFF
--- a/src/test/java/uk/ac/ox/ctl/lti13/config/Lti13Configuration.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/config/Lti13Configuration.java
@@ -1,6 +1,7 @@
 package uk.ac.ox.ctl.lti13.config;
 
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,11 +21,15 @@ import java.security.NoSuchAlgorithmException;
 @Configuration
 @EnableWebSecurity
 public class Lti13Configuration extends WebSecurityConfigurerAdapter {
+    
+	@Value("${use.state:false}")
+	private boolean useState;
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests().anyRequest().authenticated();
         Lti13Configurer lti13Configurer = new Lti13Configurer();
+        lti13Configurer.useState(useState);
         http.apply(lti13Configurer);
     }
 

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
@@ -1,0 +1,68 @@
+package uk.ac.ox.ctl.lti13.stateful;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringJUnitWebConfig(classes = {Lti13Configuration.class})
+public class Lti13Step1Test {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    public void testSecured() throws Exception {
+        this.mockMvc.perform(get("/"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testStep1Unknown() throws Exception {
+        this.mockMvc.perform(post("/lti/login_initiation/unknown"))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    public void testStep1Empty() throws Exception {
+        this.mockMvc.perform(post("/lti/login_initiation/test"))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    public void testStep1Complete() throws Exception {
+        this.mockMvc.perform(post("/lti/login_initiation/test")
+                .param("iss", "https://test.com")
+                .param("login_hint", "hint")
+                .param("target_link_uri", "https://localhost/"))
+                .andExpect(status().is3xxRedirection())
+                // We can't test the cookie as this is done by Spring Security and not the controller
+                .andExpect(redirectedUrlPattern("https://platform.test/auth/**"));
+    }
+
+}

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -1,4 +1,4 @@
-package uk.ac.ox.ctl.lti13;
+package uk.ac.ox.ctl.lti13.stateful;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -32,6 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ox.ctl.lti13.Lti13Configurer;
 import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
 import uk.ac.ox.ctl.lti13.lti.Claims;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication.OidcLaunchFlowAuthenticationProvider;
@@ -47,10 +48,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.ac.ox.ctl.lti13.Lti13Step3Test.CustomLti13Configuration;
+import static uk.ac.ox.ctl.lti13.stateful.Lti13Step3Test.CustomLti13Configuration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
@@ -1,4 +1,4 @@
-package uk.ac.ox.ctl.lti13;
+package uk.ac.ox.ctl.lti13.stateless;
 
 
 import org.junit.Before;
@@ -6,21 +6,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
 
+import static org.hamcrest.core.StringContains.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
+@TestPropertySource(properties = "use.state=true")
 @SpringJUnitWebConfig(classes = {Lti13Configuration.class})
 public class Lti13Step1Test {
 
@@ -60,8 +64,10 @@ public class Lti13Step1Test {
                 .param("iss", "https://test.com")
                 .param("login_hint", "hint")
                 .param("target_link_uri", "https://localhost/"))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("https://platform.test/auth/**"));
+                .andExpect(status().isOk())
+                // Just check that we're putting the right content in the page.
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(content().string(containsString("https://platform.test/auth/")));
     }
 
 }

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
@@ -1,0 +1,221 @@
+package uk.ac.ox.ctl.lti13.stateless;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ox.ctl.lti13.Lti13Configurer;
+import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
+import uk.ac.ox.ctl.lti13.lti.Claims;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication.OidcLaunchFlowAuthenticationProvider;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OAuth2LoginAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.StringContains.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.ac.ox.ctl.lti13.lti.Claims.TARGET_LINK_URI;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringJUnitWebConfig(classes = {Lti13Step3Test.CustomLti13Configuration.class})
+public class Lti13Step3Test {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private RestOperations restOperations;
+
+    @Autowired
+    private KeyPair keyPair;
+
+    @Autowired
+    private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+
+
+    @Configuration
+    @EnableWebSecurity
+    public static class CustomLti13Configuration extends Lti13Configuration {
+
+        @Autowired
+        private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+
+        @Autowired
+        private RestOperations restOperations;
+
+        @Bean
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+            return mock(AuthorizationRequestRepository.class);
+        }
+
+        @Override
+        public void configure(HttpSecurity http) throws Exception {
+            http.authorizeRequests().anyRequest().authenticated();
+            Lti13Configurer lti13Configurer = new Lti13Configurer() {
+
+                @Override
+                protected OidcLaunchFlowAuthenticationProvider configureAuthenticationProvider(HttpSecurity http) {
+                    // This is so that we can mock out the HTTP response for the JWKs URL.
+                    OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider = super.configureAuthenticationProvider(http);
+                    oidcLaunchFlowAuthenticationProvider.setRestOperations(restOperations);
+                    return oidcLaunchFlowAuthenticationProvider;
+                }
+
+                @Override
+                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+                    // This is so that we can put a fake original request into the repository so that the state between
+                    // the fake request and out test request will match.
+                    OAuth2LoginAuthenticationFilter oAuth2LoginAuthenticationFilter = super.configureLoginFilter(clientRegistrationRepository, oidcLaunchFlowAuthenticationProvider, authorizationRequestRepository);
+                    // Set a custom request repository
+                    oAuth2LoginAuthenticationFilter.setAuthorizationRequestRepository(
+                            CustomLti13Configuration.this.authorizationRequestRepository
+                    );
+                    return oAuth2LoginAuthenticationFilter;
+                }
+            };
+            lti13Configurer.useState(true);
+            http.apply(lti13Configurer);
+        }
+    }
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    public void testSecured() throws Exception {
+        this.mockMvc.perform(get("/"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testStep3SignedToken() throws Exception {
+        JWTClaimsSet claims = createClaims().build();
+
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = createAuthRequest().build();
+
+        when(authorizationRequestRepository.removeAuthorizationRequest(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+
+        when(restOperations.exchange(any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(jwkSet().toJSONObject().toJSONString(), HttpStatus.OK));
+        mockMvc.perform(get("/lti/login").param("id_token", createJWT(claims)).param("state", "state-123-abc"))
+                // Check that we have correct URL and state in the HTML
+                .andExpect(content().string(containsString("state-123-abc")))
+                .andExpect(content().string(containsString("https://target.link/uri")));
+    }
+
+    @Test
+    public void testStep3WrongVersion() throws Exception {
+        // Remove the LTI Version.
+        JWTClaimsSet claims = createClaims().claim(Claims.LTI_VERSION, null).build();
+
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = createAuthRequest().build();
+
+        when(authorizationRequestRepository.removeAuthorizationRequest(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+
+        when(restOperations.exchange(any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(jwkSet().toJSONObject().toJSONString(), HttpStatus.OK));
+        mockMvc.perform(get("/lti/login").param("id_token", createJWT(claims)).param("state", "state"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void testStep3Empty() throws Exception {
+        this.mockMvc.perform(get("/lti/login"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    private OAuth2AuthorizationRequest.Builder createAuthRequest() {
+        Map<String, Object> additionalParameters = new HashMap<>();
+        additionalParameters.put(OAuth2ParameterNames.REGISTRATION_ID, "test");
+        return OAuth2AuthorizationRequest.implicit()
+                .authorizationUri("https://platform.test/auth/new")
+                .redirectUri("https://tool.test/lti/login")
+                .scope("openid")
+                .state("state-123-abc")
+                .additionalParameters(additionalParameters)
+                .clientId("test-id");
+    }
+
+    private String createJWT(JWTClaimsSet claims) throws JOSEException {
+        JWSHeader header = new JWSHeader(JWSAlgorithm.RS256);
+
+        SignedJWT jwt = new SignedJWT(header, claims);
+        JWSSigner signer = new RSASSASigner(keyPair.getPrivate());
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+
+    private JWTClaimsSet.Builder createClaims() {
+        return new JWTClaimsSet.Builder()
+                    .issuer("https://platform.test")
+                    .subject("subject")
+                    .claim("scope", "openid")
+                    .audience("test-id")
+                    .expirationTime(Date.from(Instant.now().plusSeconds(10)))
+                    .claim("nonce", "test-nonce")
+                    .claim(Claims.LTI_VERSION, "1.3.0")
+                    .claim(Claims.MESSAGE_TYPE, "unchecked")
+                    .claim(Claims.ROLES, "")
+                    .claim(TARGET_LINK_URI, "https://target.link/uri")
+                    .claim(Claims.LTI_DEPLOYMENT_ID, "1");
+    }
+
+    private JWKSet jwkSet() {
+        RSAKey.Builder builder = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID("jwt-id");
+        return new JWKSet(builder.build());
+    }
+
+
+}


### PR DESCRIPTION
Add copies of the tests specifically for the stateless setup of the library. We can't easily fully test this setup because we don't have a browser environment, but we can check we're putting the right variables in the page.