### PR TITLE
Support the JWT having a kid

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/KeyPairService.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/KeyPairService.java
@@ -8,9 +8,16 @@ import java.security.KeyPair;
 public interface KeyPairService {
 
     /**
-     * Gets the key pair to be used to with a particular client.
+     * Gets the key pair to be used with a particular client.
      * @param clientRegistrationId The client's registration ID.
      * @return The KeyPair to use.
      */
     KeyPair getKeyPair(String clientRegistrationId);
+
+    /**
+     * Gets the key ID to be used with a particular client.
+     * @param clientRegistration Thie client's registration ID.
+     * @return The Key ID to use.
+     */
+    String getKeyId(String clientRegistration);
 }

--- a/src/main/java/uk/ac/ox/ctl/lti13/SingleKeyPairService.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/SingleKeyPairService.java
@@ -8,13 +8,21 @@ import java.security.KeyPair;
 public class SingleKeyPairService implements KeyPairService {
 
     private final KeyPair keyPair;
+    
+    private final String keyId;
 
-    public SingleKeyPairService(KeyPair keyPair) {
+    public SingleKeyPairService(KeyPair keyPair, String keyId) {
         this.keyPair = keyPair;
+        this.keyId = keyId;
     }
 
     @Override
     public KeyPair getKeyPair(String clientRegistrationId) {
         return keyPair;
+    }
+
+    @Override
+    public String getKeyId(String clientRegistration) {
+        return keyId;
     }
 }


### PR DESCRIPTION
When Canvas validates a JWT against a developer key that is using a JWKS URL it requires that the JWT have a `kid` field in it's header that matches one of the keys in the JWKS file (even if there is only one).

When the JWK is embedded in the developer key it doesn't require a `kid`. This change looks up a key ID and if we have one adds it to the JWT header we are building.