### PR TITLE
Fix for build failures.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -219,7 +219,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.4.0</version>
                         <!-- This is to fix building javadoc with JDK 11.0.2
                              https://bugs.openjdk.java.net/browse/JDK-8212233 -->
                         <configuration>


### PR DESCRIPTION
With Java 17 I was getting build failures when attempting to release the project, switching JDKs did fix the issue, but rather than accidentally bumping into this again we can just fix it by upgrading the plugin version.

Build failures from maven included:

Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2
    at java.lang.String.checkBoundsBeginEnd (String.java:4601)
    at java.lang.String.substring (String.java:2704)
    at org.apache.commons.lang.SystemUtils.getJavaVersionAsFloat (SystemUtils.java:1133)
    at org.apache.commons.lang.SystemUtils.<clinit> (SystemUtils.java:818)
    at org.apache.maven.plugin.javadoc.AbstractJavadocMojo.<clinit> (AbstractJavadocMojo.java:195)

and:

Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
    at org.codehaus.plexus.archiver.zip.AbstractZipArchiver.<clinit> (AbstractZipArchiver.java:113)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0 (Native Method)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance (NativeConstructorAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance (DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstanceWithCaller (Constructor.java:499)
    at java.lang.reflect.Constructor.newInstance (Constructor.java:480)
    at com.google.inject.internal.DefaultConstructionProxyFactory$ReflectiveProxy.newInstance (DefaultConstructionProxyFactory.java:126)
    at com.google.inject.internal.ConstructorInjector.provision (ConstructorInjector.java:114)
    at com.google.inject.internal.ConstructorInjector.access$000 (ConstructorInjector.java:32)
    at com.google.inject.internal.ConstructorInjector$1.call (ConstructorInjector.java:98)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision (ProvisionListenerS