### PR TITLE
Add support for lti storage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <artifactId>spring-security-lti13</artifactId>
     <version>0.0.5-SNAPSHOT</version>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.3.9</spring.version>
         <spring.security.version>5.5.2</spring.security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <artifactId>spring-security-lti13</artifactId>
     <version>0.0.5-SNAPSHOT</version>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.3.9</spring.version>
         <spring.security.version>5.5.2</spring.security.version>

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcAuthenticationToken.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcAuthenticationToken.java
@@ -7,7 +7,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import java.util.Collection;
 
 /**
- * We are validating the state on the client (browser) so we need to be able to return the state back to the client
+ * We are validating the state on the client (browser) so we need to be able to return the state/nonce back to the client
  * and so it needs to exist outside of just the authentication method.
  */
 public class OidcAuthenticationToken extends OAuth2AuthenticationToken {

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/TargetLinkUriAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/TargetLinkUriAuthenticationSuccessHandler.java
@@ -15,10 +15,9 @@ import javax.servlet.http.HttpServletResponse;
 public class TargetLinkUriAuthenticationSuccessHandler extends StateCheckingAuthenticationSuccessHandler {
 
     /**
-     * @param useState                       if true then use the state parameter for tracking logins.
-     * @param authorizationRequestRepository
+     * @param authorizationRequestRepository The authentication repository.
      */
-    public TargetLinkUriAuthenticationSuccessHandler(boolean useState, OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
+    public TargetLinkUriAuthenticationSuccessHandler(OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
         super(authorizationRequestRepository);
     }
 

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/TargetLinkUriAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/TargetLinkUriAuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import uk.ac.ox.ctl.lti13.lti.Claims;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OptimisticAuthorizationRequestRepository;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.StateCheckingAuthenticationSuccessHandler;
 
 import javax.servlet.http.HttpServletRequest;
@@ -14,10 +15,11 @@ import javax.servlet.http.HttpServletResponse;
 public class TargetLinkUriAuthenticationSuccessHandler extends StateCheckingAuthenticationSuccessHandler {
 
     /**
-     * @param useState if true then use the state parameter for tracking logins.
+     * @param useState                       if true then use the state parameter for tracking logins.
+     * @param authorizationRequestRepository
      */
-    public TargetLinkUriAuthenticationSuccessHandler(boolean useState) {
-        super(useState);
+    public TargetLinkUriAuthenticationSuccessHandler(boolean useState, OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
+        super(authorizationRequestRepository);
     }
 
     @Override

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/AuthorizationRedirectHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/AuthorizationRedirectHandler.java
@@ -10,6 +10,9 @@ public interface AuthorizationRedirectHandler {
 	
 	/**
 	 * Send a redirect to the user to start authorization but make the authorization request available.
+	 * @param request The HttpServletRequest that came in.
+	 * @param response The HttpServletResponse that we are writing the output to.
+	 * @param authorizationRequest Details of the OAuth request.   
 	 */
 	void sendRedirect(HttpServletRequest request, HttpServletResponse response, OAuth2AuthorizationRequest authorizationRequest) throws IOException;
 

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -168,11 +168,11 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 
     /**
      * Creates a least recently used hashmap.
-     * @link <a href="https://stackoverflow.com/questions/11469045/how-to-limit-the-maximum-size-of-a-map-by-removing-oldest-entries-when-limit-rea">Stackoverflow</a>
+     * @see <a href="https://stackoverflow.com/questions/11469045/how-to-limit-the-maximum-size-of-a-map-by-removing-oldest-entries-when-limit-rea">Stackoverflow</a>
      * @param maxEntries Maximum number of entries in the map
-     * @return a LinkedHashMap that limits its size.
      * @param <K> Key type.
      * @param <V> Value type.
+     * @return a LinkedHashMap that limits its size.
      */
     public static <K, V> Map<K, V> createLRUMap(final int maxEntries) {
         return new LinkedHashMap<K, V>(maxEntries*10/7, 0.7f, true) {

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.Assert;
+
+/**
+ * An implementation of an {@link AuthorizationRequestRepository} that stores
+ * {@link OAuth2AuthorizationRequest} in the {@code HttpSession}. This was copied from Spring Security, but we added
+ * support for limiting the number of concurrent sessions, this is so that when we have multiple LTI launches on the
+ * same page they work (as the browser will kick them all off at the same time).
+ *
+ * @author Joe Grandja
+ * @author Rob Winch
+ * @author Craig Andrews
+ * @author Matthew Buckett
+ * @since 5.0
+ * @see AuthorizationRequestRepository
+ * @see OAuth2AuthorizationRequest
+ */
+public final class HttpSessionOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String DEFAULT_AUTHORIZATION_REQUEST_ATTR_NAME = HttpSessionOAuth2AuthorizationRequestRepository.class
+            .getName() + ".AUTHORIZATION_REQUEST";
+
+    private final String sessionAttributeName = DEFAULT_AUTHORIZATION_REQUEST_ATTR_NAME;
+
+    private int maxConcurrentLogins = 1;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Assert.notNull(request, "request cannot be null");
+        String stateParameter = this.getStateParameter(request);
+        if (stateParameter == null) {
+            return null;
+        }
+        Map<String, OAuth2AuthorizationRequest> authorizationRequests = this.getAuthorizationRequests(request);
+        return authorizationRequests.get(stateParameter);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+                                         HttpServletResponse response) {
+        Assert.notNull(request, "request cannot be null");
+        Assert.notNull(response, "response cannot be null");
+        if (authorizationRequest == null) {
+            this.removeAuthorizationRequest(request, response);
+            return;
+        }
+        String state = authorizationRequest.getState();
+        Assert.hasText(state, "authorizationRequest.state cannot be empty");
+        if (this.maxConcurrentLogins > 1) {
+            Map<String, OAuth2AuthorizationRequest> authorizationRequests = this.getAuthorizationRequests(request);
+            authorizationRequests.put(state, authorizationRequest);
+            request.getSession().setAttribute(this.sessionAttributeName, authorizationRequests);
+        }
+        else {
+            request.getSession().setAttribute(this.sessionAttributeName, authorizationRequest);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        Assert.notNull(request, "request cannot be null");
+        String stateParameter = this.getStateParameter(request);
+        if (stateParameter == null) {
+            return null;
+        }
+        Map<String, OAuth2AuthorizationRequest> authorizationRequests = this.getAuthorizationRequests(request);
+        OAuth2AuthorizationRequest originalRequest = authorizationRequests.remove(stateParameter);
+        if (authorizationRequests.size() == 0) {
+            request.getSession().removeAttribute(this.sessionAttributeName);
+        }
+        else if (authorizationRequests.size() == 1) {
+            request.getSession().setAttribute(this.sessionAttributeName,
+                    authorizationRequests.values().iterator().next());
+        }
+        else {
+            request.getSession().setAttribute(this.sessionAttributeName, authorizationRequests);
+        }
+        return originalRequest;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                 HttpServletResponse response) {
+        Assert.notNull(response, "response cannot be null");
+        return this.removeAuthorizationRequest(request);
+    }
+
+    /**
+     * Gets the state parameter from the {@link HttpServletRequest}
+     * @param request the request to use
+     * @return the state parameter or null if not found
+     */
+    private String getStateParameter(HttpServletRequest request) {
+        return request.getParameter(OAuth2ParameterNames.STATE);
+    }
+
+    /**
+     * Gets a non-null and mutable map of {@link OAuth2AuthorizationRequest#getState()} to
+     * an {@link OAuth2AuthorizationRequest}
+     * @param request
+     * @return a non-null and mutable map of {@link OAuth2AuthorizationRequest#getState()}
+     * to an {@link OAuth2AuthorizationRequest}.
+     */
+    private Map<String, OAuth2AuthorizationRequest> getAuthorizationRequests(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        Object sessionAttributeValue = (session != null) ? session.getAttribute(this.sessionAttributeName) : null;
+        if (sessionAttributeValue == null) {
+            return new HashMap<>();
+        }
+        else if (sessionAttributeValue instanceof OAuth2AuthorizationRequest) {
+            OAuth2AuthorizationRequest auth2AuthorizationRequest = (OAuth2AuthorizationRequest) sessionAttributeValue;
+            Map<String, OAuth2AuthorizationRequest> authorizationRequests = createLRUMap(maxConcurrentLogins);
+            authorizationRequests.put(auth2AuthorizationRequest.getState(), auth2AuthorizationRequest);
+            return authorizationRequests;
+        }
+        else if (sessionAttributeValue instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, OAuth2AuthorizationRequest> authorizationRequests = (Map<String, OAuth2AuthorizationRequest>) sessionAttributeValue;
+            return authorizationRequests;
+        }
+        else {
+            throw new IllegalStateException(
+                    "authorizationRequests is supposed to be a Map or OAuth2AuthorizationRequest but actually is a "
+                            + sessionAttributeValue.getClass());
+        }
+    }
+
+    /**
+     * Configure number of  multiple {@link OAuth2AuthorizationRequest}s should be stored per
+     * session. Default is 1 (not allow multiple {@link OAuth2AuthorizationRequest}
+     * per session).
+     * @param maxConcurrentLogins true allows more than one
+     * {@link OAuth2AuthorizationRequest} to be stored per session.
+     *
+     */
+    public void setMaxConcurrentLogins(int maxConcurrentLogins) {
+        this.maxConcurrentLogins = maxConcurrentLogins;
+    }
+
+    /**
+     * Creates a least recently used hashmap.
+     * @link <a href="https://stackoverflow.com/questions/11469045/how-to-limit-the-maximum-size-of-a-map-by-removing-oldest-entries-when-limit-rea">Stackoverflow</a>
+     * @param maxEntries Maximum number of entries in the map
+     * @return a LinkedHashMap that limits its size.
+     * @param <K> Key type.
+     * @param <V> Value type.
+     */
+    public static <K, V> Map<K, V> createLRUMap(final int maxEntries) {
+        return new LinkedHashMap<K, V>(maxEntries*10/7, 0.7f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxEntries;
+            }
+        };
+    }
+
+}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -188,7 +188,7 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 			this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest, request, response);
 		}
 		
-		if (authorizationRequestRepository.hasPersistentSession(request)) {
+		if (authorizationRequestRepository.hasWorkingSession(request)) {
 			// Standard session based usage so we just do a normal browser redirect.
 			this.authorizationRedirectStrategy.sendRedirect(request, response, authorizationRequest.getAuthorizationRequestUri());
 		} else {

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -87,7 +87,6 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 				new StateAuthorizationRequestRepository(Duration.ofMinutes(1))
 		);
 	private AuthorizationRedirectHandler stateAuthorizationRedirectHandler = new StateAuthorizationRedirectHandler();
-	private boolean useState = false;
 
 	/**
 	 * Constructs an {@code OAuth2AuthorizationRequestRedirectFilter} using the provided parameters.
@@ -122,13 +121,6 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	public final void setAuthorizationRequestRepository(OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
 		Assert.notNull(authorizationRequestRepository, "authorizationRequestRepository cannot be null");
 		this.authorizationRequestRepository = authorizationRequestRepository;
-	}
-
-	/**
-	 * @param useState if true then we should use the state parameter to track logins.
-	 */
-	public void setUseState(boolean useState) {
-		this.useState = useState;
 	}
 
 	@Override

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
@@ -114,6 +114,7 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
         additionalParameters.put(OAuth2ParameterNames.RESPONSE_TYPE, "id_token");
         additionalParameters.put("login_hint", loginHint);
         additionalParameters.put("response_mode", "form_post");
+        // TODO We should really have a custom object for LTI launches
         additionalParameters.put("nonce", UUID.randomUUID().toString());
         additionalParameters.put("prompt", "none");
 

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -1,0 +1,71 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * Checks to see if we already have a valid HTTP Session containing a token, if so we store details of the login
+ * in the HTTP Session, otherwise we use store based on the state.
+ */
+public class OptimisticAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    
+    private final String SESSION_FLAG = OptimisticAuthorizationRequestRepository.class.getName()+".FLAG";
+
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> sessionBased;
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> stateBased;
+
+    public OptimisticAuthorizationRequestRepository(AuthorizationRequestRepository<OAuth2AuthorizationRequest> sessionBased, AuthorizationRequestRepository<OAuth2AuthorizationRequest> stateBased) {
+        this.sessionBased = sessionBased;
+        this.stateBased = stateBased;
+    }
+    
+    public boolean hasPersistentSession(HttpServletRequest request) {
+        // Check that we have successfully stored the state in the session before.
+        HttpSession session = request.getSession(false);
+        return session != null && session.getAttribute(SESSION_FLAG) != null;
+    }
+    
+    public void setPersistentSession(HttpServletRequest request, boolean valid) {
+        HttpSession session = request.getSession();
+        if (valid) {
+            session.setAttribute(SESSION_FLAG, true);
+        } else {
+            session.removeAttribute(SESSION_FLAG);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = sessionBased.loadAuthorizationRequest(request);
+        if (oAuth2AuthorizationRequest != null) {
+            // If we got the request successfully from the session we should use it in the future.
+            setPersistentSession(request, true);
+            return oAuth2AuthorizationRequest;
+        }
+        return stateBased.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (!hasPersistentSession(request)) {
+            stateBased.saveAuthorizationRequest(authorizationRequest, request, response);
+        }
+        sessionBased.saveAuthorizationRequest(authorizationRequest, request, response);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        OAuth2AuthorizationRequest stateRequest = stateBased.removeAuthorizationRequest(request);
+        OAuth2AuthorizationRequest sessionRequest =  sessionBased.removeAuthorizationRequest(request);
+        // Prioritise the one from the session if it's not null.
+        if (sessionRequest != null) {
+            setPersistentSession(request, true);
+            return sessionRequest;
+        } 
+        return stateRequest;
+    }
+}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -3,17 +3,17 @@ package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 /**
  * Checks to see if we already have a valid HTTP Session containing a token, if so we store details of the login
  * in the HTTP Session, otherwise we use store based on the state.
  */
 public class OptimisticAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
-    
-    private final String SESSION_FLAG = OptimisticAuthorizationRequestRepository.class.getName()+".FLAG";
+
+    private final String COOKIE_NAME = "WORKING_COOKIES";
 
     private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> sessionBased;
     private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> stateBased;
@@ -22,28 +22,36 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         this.sessionBased = sessionBased;
         this.stateBased = stateBased;
     }
-    
-    public boolean hasPersistentSession(HttpServletRequest request) {
-        // Check that we have successfully stored the state in the session before.
-        HttpSession session = request.getSession(false);
-        return session != null && session.getAttribute(SESSION_FLAG) != null;
-    }
-    
-    public void setPersistentSession(HttpServletRequest request, boolean valid) {
-        HttpSession session = request.getSession();
-        if (valid) {
-            session.setAttribute(SESSION_FLAG, true);
-        } else {
-            session.removeAttribute(SESSION_FLAG);
+
+    public boolean hasWorkingSession(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (COOKIE_NAME.equals(cookie.getName())) {
+                    return true;
+                }
+            }
         }
+        return false;
+    }
+
+    public void setWorkingSession(HttpServletResponse response) {
+        // We set our own cookie here because the session is only limited to a short period of time
+        // but we would like to use a session even after the original has expired.
+        Cookie cookie = new Cookie(COOKIE_NAME, "true");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        // Set the cookie for 1 year.
+        // TODO This should be configurable.
+        cookie.setMaxAge(60 * 60 * 24 * 356);
+        response.addCookie(cookie);
     }
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
         OAuth2AuthorizationRequest oAuth2AuthorizationRequest = sessionBased.loadAuthorizationRequest(request);
         if (oAuth2AuthorizationRequest != null) {
-            // If we got the request successfully from the session we should use it in the future.
-            setPersistentSession(request, true);
             return oAuth2AuthorizationRequest;
         }
         return stateBased.loadAuthorizationRequest(request);
@@ -51,21 +59,28 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
 
     @Override
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
-        if (!hasPersistentSession(request)) {
+        if (!hasWorkingSession(request)) {
             stateBased.saveAuthorizationRequest(authorizationRequest, request, response);
         }
         sessionBased.saveAuthorizationRequest(authorizationRequest, request, response);
     }
 
-    @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
-        OAuth2AuthorizationRequest stateRequest = stateBased.removeAuthorizationRequest(request);
-        OAuth2AuthorizationRequest sessionRequest =  sessionBased.removeAuthorizationRequest(request);
+        // This method is deprecated and should be removed soon.
+        throw new UnsupportedOperationException("We must have the response as well.");
+    }
+
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        OAuth2AuthorizationRequest stateRequest = stateBased.removeAuthorizationRequest(request, response);
+        OAuth2AuthorizationRequest sessionRequest = sessionBased.removeAuthorizationRequest(request, response);
         // Prioritise the one from the session if it's not null.
         if (sessionRequest != null) {
-            setPersistentSession(request, true);
+            // Mark that we got the state from the cookie.
+            setWorkingSession(response);
             return sessionRequest;
-        } 
+        }
         return stateRequest;
     }
 }

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRedirectHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRedirectHandler.java
@@ -46,8 +46,14 @@ public class StateAuthorizationRedirectHandler implements AuthorizationRedirectH
 			return;
 		}
 		String state = new String(encoder.quoteAsString(authorizationRequest.getState()));
+		// TODO We should be using a LTI Specific Auth request here.
+		String nonce = new String(encoder.quoteAsString((String)authorizationRequest.getAdditionalParameters().get("nonce")));
 		response.setContentType("text/html;charset=UTF-8");
 		PrintWriter writer = response.getWriter();
-		writer.append(htmlTemplate.replaceFirst("@@state@@", state).replaceFirst("@@url@@", url));
+		final String body = htmlTemplate
+				.replaceFirst("@@state@@", state)
+				.replaceFirst("@@url@@", url)
+				.replaceFirst("@@nonce@@", nonce);
+		writer.append(body);
 	}
 }

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateAuthorizationRequestRepository.java
@@ -16,6 +16,8 @@ import java.util.function.BiConsumer;
  * This store uses the state value in the initial request to lookup the request when the client
  * returns. Normally this would expose the login to a CSRF attack but we also check that the
  * remote IP address is the same in an attempt to limit this.
+ * 
+ * @see org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository
  */
 public final class StateAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
@@ -80,7 +80,7 @@ public class StateCheckingAuthenticationSuccessHandler extends
 						  Authentication authentication) throws IOException, ServletException {
 		
 		// If we got this from the Session then just redirect
-		if (authorizationRequestRepository.hasPersistentSession(request)) {
+		if (authorizationRequestRepository.hasWorkingSession(request)) {
 			super.handle(request, response, authentication);
 			return;
 		}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
@@ -113,6 +113,7 @@ public class StateCheckingAuthenticationSuccessHandler extends
 	/**
 	 * Removes temporary authentication-related data which may have been stored in the
 	 * session during the authentication process.
+	 * @param request The HttpServletRequest to clear the authentication from.
 	 */
 	protected final void clearAuthenticationAttributes(HttpServletRequest request) {
 		HttpSession session = request.getSession(false);

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/StateCheckingAuthenticationSuccessHandler.java
@@ -18,6 +18,8 @@ package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -43,7 +45,6 @@ public class StateCheckingAuthenticationSuccessHandler extends
 		AuthenticationSuccessHandler {
 
 	private final boolean useState;
-	private final JsonStringEncoder encoder = JsonStringEncoder.getInstance();
 	private final String htmlTemplate;
 	
 	private String name = "/uk/ac/ox/ctl/lti13/step-3-redirect.html";
@@ -99,11 +100,15 @@ public class StateCheckingAuthenticationSuccessHandler extends
 		}
 		OidcAuthenticationToken oidcAuthenticationToken = (OidcAuthenticationToken) authentication;
 		String state = oidcAuthenticationToken.getState();
-
+		String nonce = ((OidcUser)(oidcAuthenticationToken).getPrincipal()).getIdToken().getNonce();
 
 		response.setContentType("text/html;charset=UTF-8");
 		PrintWriter writer = response.getWriter();
-		writer.append(htmlTemplate.replaceFirst("@@state@@", state).replaceFirst("@@url@@", targetUrl));
+		writer.append(htmlTemplate
+				.replaceFirst("@@state@@", state)
+				.replaceFirst("@@url@@", targetUrl)
+				.replaceFirst("@@nonce@@", nonce)
+		);
 	}
 
 	/**

--- a/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
@@ -12,6 +12,9 @@ public class StringReader {
 
 	/**
 	 * Read a InputStream into a String. Can use readAll() when we are on Java 9 or newer.
+	 * @param inputStream The InputStream to read from.
+	 * @throws IOException If there's problem reading from the input.
+	 * @return The String contents of the stream.
 	 */
 	public static String readString(InputStream inputStream) throws IOException {
 		StringBuilder textBuilder = new StringBuilder();

--- a/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
@@ -14,14 +14,6 @@ public class StringReader {
 	 * Read a InputStream into a String. Can use readAll() when we are on Java 9 or newer.
 	 */
 	public static String readString(InputStream inputStream) throws IOException {
-		StringBuilder textBuilder = new StringBuilder();
-		try (Reader reader = new BufferedReader(new InputStreamReader
-				(inputStream, Charset.forName(StandardCharsets.UTF_8.name())))) {
-			char[] buffer = new char[1024];
-			while (reader.read(buffer) != -1) {
-				textBuilder.append(buffer);
-			}
-		}
-		return textBuilder.toString();
+		return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/utils/StringReader.java
@@ -14,6 +14,15 @@ public class StringReader {
 	 * Read a InputStream into a String. Can use readAll() when we are on Java 9 or newer.
 	 */
 	public static String readString(InputStream inputStream) throws IOException {
-		return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		StringBuilder textBuilder = new StringBuilder();
+		try (Reader reader = new BufferedReader(new InputStreamReader
+				(inputStream, Charset.forName(StandardCharsets.UTF_8.name())))) {
+			char[] buffer = new char[1024];
+			int len;
+			while ((len = reader.read(buffer)) != -1) {
+				textBuilder.append(buffer, 0, len);
+			}
+		}
+		return textBuilder.toString();
 	}
 }

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 <noscript><h1>You need to have JavaScript enable to use this.</h1></noscript>
+<h1>Loading...</h1>
 </body>
 <script>
     function showError(message) {
@@ -15,9 +16,100 @@
 
     const state = "@@state@@";
     const url = "@@url@@";
+    const nonce = "@@nonce@@";
     try {
-        window.sessionStorage.setItem('state', state);
-        document.location = url;
+        /**
+         * Attempt to generate a uuid, falls back to a random string on 
+         * @returns {string}
+         */
+        function uuid() {
+            if (self.crypto && self.crypto.randomUUID) {
+                return self.crypto.randomUUID();
+            } else {
+                // IE 11 Doesn't have randomUUID so fall back to short random string.
+                return (Math.random() + 1).toString(36).substring(2, 5)
+            }
+        }
+        const platformOrigin = "*"; // Canvas doesn't support origin.
+        let targetFrame = window.parent || window.opener
+
+        // If we don't get any response from the platform show something to the user.
+        setTimeout(function() {
+            showError("Timeout handling LTI authentication (storage), please retry");
+        }, 5000)
+        
+        // Have we set the values in the storage?
+        let setState = false
+        let setNonce = false
+
+        let stateUuid = uuid();
+        postAndHandle(targetFrame, {
+            "subject": "org.imsglobal.lti.put_data",
+            "message_id": stateUuid,
+            "key": "state_"+ state,
+            "value": state
+        } , platformOrigin, function(event) {
+            setState = true
+            redirectIfValid()
+        })
+
+        let nonceUuid = uuid();
+        postAndHandle(targetFrame, {
+            "subject": "org.imsglobal.lti.put_data",
+            "message_id": nonceUuid,
+            "key": "nonce_"+ nonce,
+            "value": nonce
+        } , platformOrigin, function(event) {
+            setNonce = true
+            redirectIfValid()
+        })
+
+        /**
+         * Send a message and handle its response.
+         * @param target 
+         * @param message
+         * @param origin
+         * @param onResponse
+         */
+        function postAndHandle(target, message, origin, onResponse) {
+            function handler(event) {
+                // This isn't a message we're expecting
+                if (typeof event.data !== "object"){
+                    return;
+                }
+                // Validate it's the response type you expect
+                if (event.data.subject !== message.subject+ ".response") {
+                    return;
+                }
+                // Validate the message id matches the id you sent
+                if (event.data.message_id !== message.message_id) {
+                    return;
+                }
+                // Validate that the event's origin is the same as the derived platform origin
+                if (origin !== '*' && event.origin !== origin) {
+                    return;
+                }
+                // handle errors
+                if (event.data.error){
+                    // handle errors (message and code)
+                    console.log(event.data.error)
+                    return;
+                }
+                onResponse(event)
+                // Cleanup now we've got our message.
+                window.removeEventListener('message', handler)
+            }
+            window.addEventListener('message', handler); 
+            // Now the handler is setup we can send our message.
+            target.postMessage(message, origin);
+        }
+        
+        function redirectIfValid() {
+            // Only redirect once we've had confirmation both are set
+            if (setNonce && setState) {
+                document.location = url;
+            }
+        }
     } catch (error) {
         if (error.name === 'SecurityError') {
             showError("You have cookies disabled, please enable them for this site.");

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -17,6 +17,11 @@
     const state = "@@state@@";
     const url = "@@url@@";
     const nonce = "@@nonce@@";
+
+    // Have we set the values in the storage?
+    let setState = false
+    let setNonce = false
+    
     try {
         /**
          * Attempt to generate a uuid, falls back to a random string on 
@@ -37,10 +42,7 @@
         setTimeout(function() {
             showError("Timeout handling LTI authentication (storage), please retry");
         }, 5000)
-        
-        // Have we set the values in the storage?
-        let setState = false
-        let setNonce = false
+
 
         let stateUuid = uuid();
         postAndHandle(targetFrame, {

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
@@ -17,6 +17,11 @@
     const state = "@@state@@";
     const url = "@@url@@"
     const nonce = "@@nonce@@";
+
+    // Have we set the values in the storage?
+    let savedState = null;
+    let savedNonce = null;
+    
     try {
         /**
          * Attempt to generate a uuid, falls back to a random string on
@@ -38,9 +43,7 @@
             showError("Timeout handling LTI authentication (retrieval), please retry");
         }, 5000)
 
-        // Have we set the values in the storage?
-        let savedState;
-        let savedNonce;
+
 
         let stateUuid = uuid();
         postAndHandle(targetFrame, {

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 <noscript><h1>You need to have JavaScript enable to use this.</h1></noscript>
+<h1>Redirecting....</h1>
 </body>
 <script>
     function showError(message) {
@@ -15,12 +16,103 @@
 
     const state = "@@state@@";
     const url = "@@url@@"
+    const nonce = "@@nonce@@";
     try {
-        if (state !== window.sessionStorage.getItem('state')) {
-            showError('Saved state does not match.');
-        } else {
-            document.location = url;
+        /**
+         * Attempt to generate a uuid, falls back to a random string on
+         * @returns {string}
+         */
+        function uuid() {
+            if (self.crypto && self.crypto.randomUUID) {
+                return self.crypto.randomUUID();
+            } else {
+                // IE 11 Doesn't have randomUUID so fall back to short random string.
+                return (Math.random() + 1).toString(36).substring(2, 5)
+            }
         }
+        const platformOrigin = "*"; // Canvas doesn't support origin.
+        let targetFrame = window.parent || window.opener
+
+        // If we don't get any response from the platform show something to the user.
+        setTimeout(function() {
+            showError("Timeout handling LTI authentication (retrieval), please retry");
+        }, 5000)
+
+        // Have we set the values in the storage?
+        let savedState;
+        let savedNonce;
+
+        let stateUuid = uuid();
+        postAndHandle(targetFrame, {
+            "subject": "org.imsglobal.lti.get_data",
+            "message_id": stateUuid,
+            "key": "state_"+ state
+        } , platformOrigin, function(event) {
+            savedState = event.data.value
+            checkAndRedirect()
+        })
+
+        let nonceUuid = uuid();
+        postAndHandle(targetFrame, {
+            "subject": "org.imsglobal.lti.get_data",
+            "message_id": nonceUuid,
+            "key": "nonce_"+ nonce
+        } , platformOrigin, function(event) {
+            savedNonce = event.data.value
+            checkAndRedirect()
+        })
+
+        function checkAndRedirect() {
+            // Only redirect once we've had confirmation both are set
+            if (savedNonce && savedState) {
+                if (nonce === savedNonce && state === savedState) {
+                    document.location = url
+                } else {
+                    showError('Saved state and nonce do not match');
+                }
+            }
+        }
+
+        /**
+         * Send a message and handle its response.
+         * @param target
+         * @param message
+         * @param origin
+         * @param onResponse
+         */
+        function postAndHandle(target, message, origin, onResponse) {
+            function handler(event) {
+                // This isn't a message we're expecting
+                if (typeof event.data !== "object"){
+                    return;
+                }
+                // Validate it's the response type you expect
+                if (event.data.subject !== message.subject+ ".response") {
+                    return;
+                }
+                // Validate the message id matches the id you sent
+                if (event.data.message_id !== message.message_id) {
+                    return;
+                }
+                // Validate that the event's origin is the same as the derived platform origin
+                if (origin !== '*' && event.origin !== origin) {
+                    return;
+                }
+                // handle errors
+                if (event.data.error){
+                    // handle errors (message and code)
+                    console.log(event.data.error)
+                    return;
+                }
+                onResponse(event)
+                // Cleanup now we've got our message.
+                window.removeEventListener('message', handler)
+            }
+            window.addEventListener('message', handler);
+            // Now the handler is setup we can send our message.
+            target.postMessage(message, origin);
+        }
+
     } catch (error) {
         if (error.name === 'SecurityError') {
             showError('You have cookies disabled, please enable them for this site.')

--- a/src/test/java/uk/ac/ox/ctl/lti13/config/Lti13Configuration.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/config/Lti13Configuration.java
@@ -22,14 +22,10 @@ import java.security.NoSuchAlgorithmException;
 @EnableWebSecurity
 public class Lti13Configuration extends WebSecurityConfigurerAdapter {
     
-	@Value("${use.state:false}")
-	private boolean useState;
-
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests().anyRequest().authenticated();
         Lti13Configurer lti13Configurer = new Lti13Configurer();
-        lti13Configurer.useState(useState);
         http.apply(lti13Configurer);
     }
 

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
@@ -14,6 +14,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
 
+import javax.servlet.http.Cookie;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -57,9 +59,11 @@ public class Lti13Step1Test {
     @Test
     public void testStep1Complete() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/test")
-                .param("iss", "https://test.com")
-                .param("login_hint", "hint")
-                .param("target_link_uri", "https://localhost/"))
+                    .param("iss", "https://test.com")
+                    .param("login_hint", "hint")
+                    .param("target_link_uri", "https://localhost/")
+                    .cookie(new Cookie("WORKING_COOKIES", "true"))
+                )
                 .andExpect(status().is3xxRedirection())
                 // We can't test the cookie as this is done by Spring Security and not the controller
                 .andExpect(redirectedUrlPattern("https://platform.test/auth/**"));

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -193,7 +193,7 @@ public class Lti13Step3Test {
                     .subject("subject")
                     .claim("scope", "openid")
                     .audience("test-id")
-                    .expirationTime(Date.from(Instant.now().plusSeconds(10)))
+                    .expirationTime(Date.from(Instant.now().plusSeconds(300)))
                     .claim("nonce", "test-nonce")
                     .claim(Claims.LTI_VERSION, "1.3.0")
                     .claim(Claims.MESSAGE_TYPE, "unchecked")

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -37,6 +37,7 @@ import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
 import uk.ac.ox.ctl.lti13.lti.Claims;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication.OidcLaunchFlowAuthenticationProvider;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OAuth2LoginAuthenticationFilter;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OptimisticAuthorizationRequestRepository;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -101,7 +102,7 @@ public class Lti13Step3Test {
                 }
 
                 @Override
-                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
                     // This is so that we can put a fake original request into the repository so that the state between
                     // the fake request and out test request will match.
                     OAuth2LoginAuthenticationFilter oAuth2LoginAuthenticationFilter = super.configureLoginFilter(clientRegistrationRepository, oidcLaunchFlowAuthenticationProvider, authorizationRequestRepository);

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
@@ -61,9 +61,10 @@ public class Lti13Step1Test {
     @Test
     public void testStep1Complete() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/test")
-                .param("iss", "https://test.com")
-                .param("login_hint", "hint")
-                .param("target_link_uri", "https://localhost/"))
+                    .param("iss", "https://test.com")
+                    .param("login_hint", "hint")
+                    .param("target_link_uri", "https://localhost/")
+                )
                 .andExpect(status().isOk())
                 // Just check that we're putting the right content in the page.
                 .andDo(MockMvcResultHandlers.print())

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
@@ -117,7 +117,6 @@ public class Lti13Step3Test {
                     return oAuth2LoginAuthenticationFilter;
                 }
             };
-            lti13Configurer.useState(true);
             http.apply(lti13Configurer);
         }
     }

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
@@ -200,7 +200,7 @@ public class Lti13Step3Test {
                     .subject("subject")
                     .claim("scope", "openid")
                     .audience("test-id")
-                    .expirationTime(Date.from(Instant.now().plusSeconds(10)))
+                    .expirationTime(Date.from(Instant.now().plusSeconds(300)))
                     .claim("nonce", "test-nonce")
                     .claim(Claims.LTI_VERSION, "1.3.0")
                     .claim(Claims.MESSAGE_TYPE, "unchecked")

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
@@ -39,6 +39,7 @@ import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
 import uk.ac.ox.ctl.lti13.lti.Claims;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication.OidcLaunchFlowAuthenticationProvider;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OAuth2LoginAuthenticationFilter;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OptimisticAuthorizationRequestRepository;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -105,7 +106,7 @@ public class Lti13Step3Test {
                 }
 
                 @Override
-                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+                protected OAuth2LoginAuthenticationFilter configureLoginFilter(ClientRegistrationRepository clientRegistrationRepository, OidcLaunchFlowAuthenticationProvider oidcLaunchFlowAuthenticationProvider, OptimisticAuthorizationRequestRepository authorizationRequestRepository) {
                     // This is so that we can put a fake original request into the repository so that the state between
                     // the fake request and out test request will match.
                     OAuth2LoginAuthenticationFilter oAuth2LoginAuthenticationFilter = super.configureLoginFilter(clientRegistrationRepository, oidcLaunchFlowAuthenticationProvider, authorizationRequestRepository);

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step3Test.java
@@ -74,7 +74,7 @@ public class Lti13Step3Test {
     private KeyPair keyPair;
 
     @Autowired
-    private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+    private OptimisticAuthorizationRequestRepository authorizationRequestRepository;
 
 
     @Configuration
@@ -82,14 +82,14 @@ public class Lti13Step3Test {
     public static class CustomLti13Configuration extends Lti13Configuration {
 
         @Autowired
-        private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+        private OptimisticAuthorizationRequestRepository authorizationRequestRepository;
 
         @Autowired
         private RestOperations restOperations;
 
         @Bean
-        AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
-            return mock(AuthorizationRequestRepository.class);
+        OptimisticAuthorizationRequestRepository authorizationRequestRepository() {
+            return mock(OptimisticAuthorizationRequestRepository.class);
         }
 
         @Override
@@ -201,6 +201,7 @@ public class Lti13Step3Test {
                     .subject("subject")
                     .claim("scope", "openid")
                     .audience("test-id")
+                    .issueTime(new Date())
                     .expirationTime(Date.from(Instant.now().plusSeconds(300)))
                     .claim("nonce", "test-nonce")
                     .claim(Claims.LTI_VERSION, "1.3.0")


### PR DESCRIPTION
This adds support for the LTI storage for handle the launch. This is where the platform where the tool is being launched from stores the state/nonce during the launch.

This also adds back support for HttpSession based storage, we try to set a cookie during login and if we see that cookie again we know that the browser supports cookies in the iframe and so use the session to handle the login in future.