### PR TITLE
AB#64981 Add back support for mobile apps.

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -180,7 +180,9 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 			this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest, request, response);
 		}
 		
-		if (authorizationRequestRepository.hasWorkingSession(request)) {
+		// Currently in Canvas it always says we support the storage platform, but the mobile apps 
+		// currently don't and so shouldn't send through this parameter.
+		if (authorizationRequestRepository.hasWorkingSession(request) || hasNoPlatform(request)) {
 			// Standard session based usage so we just do a normal browser redirect.
 			this.authorizationRedirectStrategy.sendRedirect(request, response, authorizationRequest.getAuthorizationRequestUri());
 		} else {
@@ -189,6 +191,15 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 		}
 		// We don't need to save the request as the final URL to redirect to is in the claims normally we would save
 		// the current request here.
+	}
+
+	/**
+	 * Check that the LTI Storage Platform is unavailable.
+	 * @param request The HttpServletRequet to look into.
+	 * @return true if the service launching the LTI tool doesn't support the LTI Storage Platform.
+	 */
+	private boolean hasNoPlatform(HttpServletRequest request) {
+		return request.getParameter("lti_storage_target") == null;
 	}
 
 	private void unsuccessfulRedirectForAuthorization(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -40,7 +40,13 @@
 
         // If we don't get any response from the platform show something to the user.
         setTimeout(function() {
-            showError("Timeout handling LTI authentication (storage), please retry");
+            // Mobile apps users will see this the first time as they don't support the storage platform
+            // but their LTI launch says they do. However they do support cookies so we should be able
+            // to use the session when they complete the LTI launch.
+            showError("Timeout handling LTI authentication (storage), redirecting with anyway.");
+            setTimeout(function() {
+                document.location = url;
+            }, 2000)
         }, 5000)
 
 

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -43,7 +43,7 @@
             // Mobile apps users will see this the first time as they don't support the storage platform
             // but their LTI launch says they do. However they do support cookies so we should be able
             // to use the session when they complete the LTI launch.
-            showError("Timeout handling LTI authentication (storage), redirecting with anyway.");
+            showError("Timeout handling LTI authentication (storage), redirecting anyway.");
             setTimeout(function() {
                 document.location = url;
             }, 2000)

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
@@ -69,4 +69,18 @@ public class Lti13Step1Test {
                 .andExpect(redirectedUrlPattern("https://platform.test/auth/**"));
     }
 
+
+    @Test
+    public void testStep1NoStorageTarget() throws Exception {
+        // There's no explicit support for the LTI storage platform so we assume that we can't use it and just
+        // redirect
+        this.mockMvc.perform(post("/lti/login_initiation/test")
+                        .param("iss", "https://test.com")
+                        .param("login_hint", "hint")
+                        .param("target_link_uri", "https://localhost/")
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("https://platform.test/auth/**"));
+    }
+
 }

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ox.ctl.lti13.config.Lti13Configuration;
@@ -64,11 +63,12 @@ public class Lti13Step1Test {
                     .param("iss", "https://test.com")
                     .param("login_hint", "hint")
                     .param("target_link_uri", "https://localhost/")
+                    .param("lti_storage_target", "_parent")
                 )
                 .andExpect(status().isOk())
                 // Just check that we're putting the right content in the page.
-                .andDo(MockMvcResultHandlers.print())
                 .andExpect(content().string(containsString("https://platform.test/auth/")));
     }
+
 
 }


### PR DESCRIPTION
We assume that things will work with a cookie based login if the platform storage specification isn't available. This means that mobile users will see a message the first time they login (as we try to use the platform service) but then after that they will get the cookie set and will just get redirected.