### PR TITLE
AB#64981 Support mobile on 1st login

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class OptimisticAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
+    public static final String ATTRIBUTE_NAME = OptimisticAuthorizationRequestRepository.class.getName() + "#WORKING_SESSION";
     private final String COOKIE_NAME = "WORKING_COOKIES";
 
     private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> sessionBased;
@@ -24,6 +25,11 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
     }
 
     public boolean hasWorkingSession(HttpServletRequest request) {
+        // We don't want to wait for the next request to use the session, so as well as looking for cookies we
+        // check for an attribute on the request.
+        if (request.getAttribute(ATTRIBUTE_NAME) != null) {
+            return true;
+        }
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
@@ -35,7 +41,7 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         return false;
     }
 
-    public void setWorkingSession(HttpServletResponse response) {
+    public void setWorkingSession(HttpServletRequest request, HttpServletResponse response) {
         // We set our own cookie here because the session is only limited to a short period of time
         // but we would like to use a session even after the original has expired.
         Cookie cookie = new Cookie(COOKIE_NAME, "true");
@@ -46,6 +52,8 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         // TODO This should be configurable.
         cookie.setMaxAge(60 * 60 * 24 * 356);
         response.addCookie(cookie);
+        // Mark the current request as having a working session.
+        request.setAttribute(ATTRIBUTE_NAME, true);
     }
 
     @Override
@@ -78,7 +86,7 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         // Prioritise the one from the session if it's not null.
         if (sessionRequest != null) {
             // Mark that we got the state from the cookie.
-            setWorkingSession(response);
+            setWorkingSession(request, response);
             return sessionRequest;
         }
         return stateRequest;

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -38,12 +39,14 @@ import uk.ac.ox.ctl.lti13.lti.Claims;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.authentication.OidcLaunchFlowAuthenticationProvider;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OAuth2LoginAuthenticationFilter;
 import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.OptimisticAuthorizationRequestRepository;
+import uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web.StateAuthorizationRequestRepository;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.security.KeyPair;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -51,6 +54,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.ac.ox.ctl.lti13.stateful.Lti13Step3Test.CustomLti13Configuration;
 
@@ -71,7 +75,8 @@ public class Lti13Step3Test {
     private KeyPair keyPair;
 
     @Autowired
-    private OptimisticAuthorizationRequestRepository authorizationRequestRepository;
+    @Qualifier("http")
+    private AuthorizationRequestRepository authorizationRequestRepository;
 
 
     @Configuration
@@ -84,9 +89,22 @@ public class Lti13Step3Test {
         @Autowired
         private RestOperations restOperations;
 
+        @Bean(name = "http")
+        AuthorizationRequestRepository authorizationRequestRepository() {
+            return mock(AuthorizationRequestRepository.class);
+        }
+
         @Bean
-        OptimisticAuthorizationRequestRepository authorizationRequestRepository() {
-            return mock(OptimisticAuthorizationRequestRepository.class);
+        StateAuthorizationRequestRepository stateAuthorizationRequestRepository() {
+            return new StateAuthorizationRequestRepository(Duration.ZERO);
+        }
+
+        @Bean
+        OptimisticAuthorizationRequestRepository authorizationRequestRepository(
+                @Qualifier("http") AuthorizationRequestRepository requestRepository,
+                StateAuthorizationRequestRepository stateAuthorizationRequestRepository
+        ) {
+            return new OptimisticAuthorizationRequestRepository(requestRepository, stateAuthorizationRequestRepository);
         }
 
         @Override
@@ -149,6 +167,26 @@ public class Lti13Step3Test {
     }
 
     @Test
+    public void testStep3SignedTokenNoCookie() throws Exception {
+        // Here we haven't already marked the browser as having a working session based on cookies, but we 
+        // do manage to retrieve the 
+        JWTClaimsSet claims = createClaims().build();
+
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = createAuthRequest().build();
+
+        when(authorizationRequestRepository.loadAuthorizationRequest(any(HttpServletRequest.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+        when(authorizationRequestRepository.removeAuthorizationRequest(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+
+        when(restOperations.exchange(any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(jwkSet().toString(), HttpStatus.OK));
+        mockMvc.perform(get("/lti/login").param("id_token", createJWT(claims)).param("state", "state"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(cookie().exists("WORKING_COOKIES"));
+    }
+
+    @Test
     public void testStep3WrongVersion() throws Exception {
         // Remove the LTI Version.
         JWTClaimsSet claims = createClaims().claim(Claims.LTI_VERSION, null).build();
@@ -193,17 +231,17 @@ public class Lti13Step3Test {
 
     private JWTClaimsSet.Builder createClaims() {
         return new JWTClaimsSet.Builder()
-                    .issuer("https://platform.test")
-                    .subject("subject")
-                    .claim("scope", "openid")
-                    .audience("test-id")
-                    .issueTime(new Date())
-                    .expirationTime(Date.from(Instant.now().plusSeconds(300)))
-                    .claim("nonce", "test-nonce")
-                    .claim(Claims.LTI_VERSION, "1.3.0")
-                    .claim(Claims.MESSAGE_TYPE, "unchecked")
-                    .claim(Claims.ROLES, "")
-                    .claim(Claims.LTI_DEPLOYMENT_ID, "1");
+                .issuer("https://platform.test")
+                .subject("subject")
+                .claim("scope", "openid")
+                .audience("test-id")
+                .issueTime(new Date())
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .claim("nonce", "test-nonce")
+                .claim(Claims.LTI_VERSION, "1.3.0")
+                .claim(Claims.MESSAGE_TYPE, "unchecked")
+                .claim(Claims.ROLES, "")
+                .claim(Claims.LTI_DEPLOYMENT_ID, "1");
     }
 
     private JWKSet jwkSet() {


### PR DESCRIPTION
It was only allowing logins to work on the second login as although we set a cookie on step 3 of the login to say cookie based logins worked we only checked for cookies in the incomming request when looking at how to redirect users.

Now we set a request attribute as well as a cookie to mark that the user has a browser that supports cookies and we then as well as checking for the cookie check for the request attribute.