### PR TITLE
Drop TokenRetriever from being a `@Service`

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/TokenRetriever.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/TokenRetriever.java
@@ -33,7 +33,6 @@ import java.util.*;
  * @see <a href="https://www.imsglobal.org/spec/lti/v1p3/#token-endpoint-claim-and-services">https://www.imsglobal.org/spec/lti/v1p3/#token-endpoint-claim-and-services</a>
  * @see <a href="https://www.imsglobal.org/spec/security/v1p0/#using-json-web-tokens-with-oauth-2-0-client-credentials-grant">https://www.imsglobal.org/spec/security/v1p0/#using-json-web-tokens-with-oauth-2-0-client-credentials-grant</a>
  */
-@Component
 public class TokenRetriever {
 
     private final Logger log = LoggerFactory.getLogger(TokenRetriever.class);


### PR DESCRIPTION
Otherwise this causes problems when the component scan picks up this. This normally only happens when running an application in the `uk.ac.ox.ctl` package.