### PR TITLE
Switch from org.imsglobal.lti prefix to lti

### DIFF
--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -52,7 +52,7 @@
 
         let stateUuid = uuid();
         postAndHandle(targetFrame, {
-            "subject": "org.imsglobal.lti.put_data",
+            "subject": "lti.put_data",
             "message_id": stateUuid,
             "key": "state_"+ state,
             "value": state
@@ -63,7 +63,7 @@
 
         let nonceUuid = uuid();
         postAndHandle(targetFrame, {
-            "subject": "org.imsglobal.lti.put_data",
+            "subject": "lti.put_data",
             "message_id": nonceUuid,
             "key": "nonce_"+ nonce,
             "value": nonce

--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-3-redirect.html
@@ -47,7 +47,7 @@
 
         let stateUuid = uuid();
         postAndHandle(targetFrame, {
-            "subject": "org.imsglobal.lti.get_data",
+            "subject": "lti.get_data",
             "message_id": stateUuid,
             "key": "state_"+ state
         } , platformOrigin, function(event) {
@@ -57,7 +57,7 @@
 
         let nonceUuid = uuid();
         postAndHandle(targetFrame, {
-            "subject": "org.imsglobal.lti.get_data",
+            "subject": "lti.get_data",
             "message_id": nonceUuid,
             "key": "nonce_"+ nonce
         } , platformOrigin, function(event) {


### PR DESCRIPTION
window.postMessage subject prefixes have been shortened to remove the org.imsglobal prefix. This is no longer supported by Canvas in July 2023 so we need to switch to using the new shorter name.