### PR TITLE
Allow registration lookups to be customised.

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiationRegistrationResolver.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiationRegistrationResolver.java
@@ -1,0 +1,14 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Interface to allow custom ways of resolving the registration ID. Eg by client ID, or deployment ID.
+ */
+public interface OIDCInitiationRegistrationResolver {
+
+    /*
+     ** Finds a registration out of a request during a login initiation.
+     */
+    String resolve(HttpServletRequest request);
+}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/PathOIDCInitiationRegistrationResolver.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/PathOIDCInitiationRegistrationResolver.java
@@ -1,0 +1,29 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Assert;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class PathOIDCInitiationRegistrationResolver implements OIDCInitiationRegistrationResolver {
+    
+    private static final String REGISTRATION_ID_URI_VARIABLE_NAME = "registrationId";
+
+    private final AntPathRequestMatcher authorizationRequestMatcher;
+
+    public PathOIDCInitiationRegistrationResolver(String authorizationRequestBaseUri) {
+        Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri cannot be empty");
+        this.authorizationRequestMatcher = new AntPathRequestMatcher(
+                authorizationRequestBaseUri + "/{" + REGISTRATION_ID_URI_VARIABLE_NAME + "}");
+    }
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        if (this.authorizationRequestMatcher.matches(request)) {
+            return this.authorizationRequestMatcher
+                    .extractUriTemplateVariables(request).get(REGISTRATION_ID_URI_VARIABLE_NAME);
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
On the first step of LTI launch we allow the lookup of the registration to be customised by the calling application. This means it's possible to use the same URL across all configurations and use a parameter from the request to lookup the registration ID.