### PR TITLE
Better error handling on initiation.

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/InvalidClientRegistrationIdException.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/InvalidClientRegistrationIdException.java
@@ -1,0 +1,15 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+/**
+ * This is for when we fail to find a client registration.
+ */
+class InvalidClientRegistrationIdException extends IllegalArgumentException {
+
+	/**
+	 * @param message the exception message
+	 */
+	InvalidClientRegistrationIdException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/InvalidInitiationRequestException.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/InvalidInitiationRequestException.java
@@ -1,0 +1,14 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.client.lti.web;
+
+/**
+ * This is for use when the client sends a request that's missing required parameters.
+ */
+public class InvalidInitiationRequestException extends RuntimeException {
+
+    /**
+     * @param message the exception message
+     */
+    InvalidInitiationRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -208,7 +208,13 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 		if (logger.isErrorEnabled()) {
 			logger.error("Authorization Request failed: " + failed.toString(), failed);
 		}
-		response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+		if (failed instanceof InvalidInitiationRequestException) {
+			response.sendError(HttpStatus.BAD_REQUEST.value(), failed.getMessage());
+		} else if (failed instanceof InvalidClientRegistrationIdException) {
+			response.sendError(HttpStatus.NOT_FOUND.value(), failed.getMessage());
+		} else {
+			response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+		}
 	}
 
 	private static final class DefaultThrowableAnalyzer extends ThrowableAnalyzer {

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OIDCInitiatingLoginRequestResolver.java
@@ -87,7 +87,8 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
 
         ClientRegistration clientRegistration = this.clientRegistrationRepository.findByRegistrationId(registrationId);
         if (clientRegistration == null) {
-            throw new IllegalArgumentException("Invalid Client Registration with Id: " + registrationId);
+            // We use a custom exception here so callers can specifically handle this case.
+            throw new InvalidClientRegistrationIdException("No Client Registration found with ID: " + registrationId);
         }
 
         OAuth2AuthorizationRequest.Builder builder;
@@ -95,6 +96,7 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
         if (AuthorizationGrantType.IMPLICIT.equals(clientRegistration.getAuthorizationGrantType())) {
             builder = OAuth2AuthorizationRequest.implicit();
         } else {
+            // This is a configuration problem.
             throw new IllegalArgumentException("Invalid Authorization Grant Type ("  +
                     clientRegistration.getAuthorizationGrantType().getValue() +
                     ") for Client Registration with Id: " + clientRegistration.getRegistrationId());
@@ -102,17 +104,17 @@ public class OIDCInitiatingLoginRequestResolver implements OAuth2AuthorizationRe
 
         String iss = request.getParameter("iss");
         if (iss == null) {
-            throw new IllegalArgumentException("Required parameter iss was not supplied.");
+            throw new InvalidInitiationRequestException("Required parameter iss was not supplied.");
         }
 
         String loginHint = request.getParameter("login_hint");
         if (loginHint == null) {
-            throw new IllegalArgumentException("Required parameter login_hint was not supplied.");
+            throw new InvalidInitiationRequestException("Required parameter login_hint was not supplied.");
         }
 
         String targetLinkUri = request.getParameter("target_link_uri");
         if (targetLinkUri == null) {
-            throw new IllegalArgumentException("Required parameter target_link_uri was not supplied");
+            throw new InvalidInitiationRequestException("Required parameter target_link_uri was not supplied");
         }
 
         String redirectUriStr = this.expandRedirectUri(request, clientRegistration, redirectUriAction);

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step1Test.java
@@ -47,13 +47,13 @@ public class Lti13Step1Test {
     @Test
     public void testStep1Unknown() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/unknown"))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
     public void testStep1Empty() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/test"))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateless/Lti13Step1Test.java
@@ -48,13 +48,13 @@ public class Lti13Step1Test {
     @Test
     public void testStep1Unknown() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/unknown"))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
     public void testStep1Empty() throws Exception {
         this.mockMvc.perform(post("/lti/login_initiation/test"))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test


### PR DESCRIPTION
Rather than blowing up with a 500 error when we can't find a registration, or parameters are missing we instead return a 4xx error.

404 for an unknown registration id.
400 for missing parameters.

This makes it easier for people integrating with the service to debug the errors.