### PR TITLE
Support anonymous launches LTI 1.3 launches.

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcLaunchFlowAuthenticationProvider.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcLaunchFlowAuthenticationProvider.java
@@ -29,7 +29,6 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
-import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
@@ -41,6 +40,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 import uk.ac.ox.ctl.lti13.security.oauth2.core.endpoint.OIDCLaunchFlowResponse;
+import uk.ac.ox.ctl.lti13.security.oauth2.core.user.LtiOauth2User;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -114,7 +114,7 @@ public class OidcLaunchFlowAuthenticationProvider implements AuthenticationProvi
 		Set<GrantedAuthority> authorities = new HashSet<>();
 		OidcUserAuthority authority = new OidcUserAuthority(idToken, null);
 		authorities.add(authority);
-		DefaultOidcUser oidcUser = new DefaultOidcUser(authorities, idToken);
+		LtiOauth2User oidcUser = new LtiOauth2User(authorities, idToken);
 
 		Collection<? extends GrantedAuthority> mappedAuthorities =
 			this.authoritiesMapper.mapAuthorities(oidcUser.getAuthorities());

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcTokenValidator.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/authentication/OidcTokenValidator.java
@@ -46,10 +46,7 @@ final class OidcTokenValidator {
 		if (issuer == null) {
 			throwInvalidIdTokenException("No issuer in token.");
 		}
-		String subject = idToken.getSubject();
-		if (subject == null) {
-			throwInvalidIdTokenException("No subject in token.");
-		}
+		// We don't validate that there's a subject claim as an anonymous launch doesn't include one.
 		List<String> audience = idToken.getAudience();
 		if (CollectionUtils.isEmpty(audience)) {
 			throwInvalidIdTokenException("No audience in token.");

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/core/user/LtiOauth2User.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/core/user/LtiOauth2User.java
@@ -1,0 +1,89 @@
+package uk.ac.ox.ctl.lti13.security.oauth2.core.user;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.Assert;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * LTI launches can happen when there isn't a user logged in. In this situation
+ * there isn't a subject claim and so we need to support this.
+ */
+public class LtiOauth2User implements OidcUser {
+    
+    public static final String ANONYMOUS = "anonymous";
+
+    private final OidcIdToken idToken;
+    private final Set<GrantedAuthority> authorities;
+    private final String nameAttributeKey;
+
+    public LtiOauth2User(Collection<? extends GrantedAuthority> authorities, OidcIdToken idToken) {
+        this(authorities, idToken, IdTokenClaimNames.SUB);
+    }
+    /**
+     * Constructs a {@code DefaultOAuth2User} using the provided parameters.
+     *
+     * @param authorities      the authorities granted to the user
+     * @param idToken          the ID Token containing claims about the user
+     */
+    public LtiOauth2User(Collection<? extends GrantedAuthority> authorities, OidcIdToken idToken, String nameAttributeKey) {
+        Assert.notNull(idToken, "idToken cannot be null");
+        Assert.hasText(nameAttributeKey, "nameAttributeKey cannot be empty");
+        this.authorities = (authorities != null)
+                ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
+                : Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));
+        this.idToken = idToken;
+        this.nameAttributeKey = nameAttributeKey;
+    }
+
+    private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {
+        SortedSet<GrantedAuthority> sortedAuthorities = new TreeSet<>(
+                Comparator.comparing(GrantedAuthority::getAuthority));
+        sortedAuthorities.addAll(authorities);
+        return sortedAuthorities;
+    }
+
+    @Override
+    public String getName() {
+        String name = idToken.getClaimAsString(nameAttributeKey);
+        return name == null ? ANONYMOUS : name;
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return idToken.getClaims();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        // In the LTI launches we never do additional user lookups so we just always return null.
+        return null;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return idToken;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return idToken.getClaims();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+}

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -168,6 +168,24 @@ public class Lti13Step3Test {
     }
 
     @Test
+    public void testStep3SignedTokenAnonymous() throws Exception {
+        // When it's an anonymous request there's no subject in the claims.
+        JWTClaimsSet claims = createClaims().subject(null).build();
+
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest = createAuthRequest().build();
+
+        when(authorizationRequestRepository.loadAuthorizationRequest(any(HttpServletRequest.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+        when(authorizationRequestRepository.removeAuthorizationRequest(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(oAuth2AuthorizationRequest);
+
+        when(restOperations.exchange(any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(jwkSet().toString(), HttpStatus.OK));
+        mockMvc.perform(post("/lti/login").param("id_token", createJWT(claims)).param("state", "state").cookie(new Cookie("WORKING_COOKIES", "true")))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
     public void testStep3SignedTokenNoCookie() throws Exception {
         // Here we haven't already marked the browser as having a working session based on cookies, but we 
         // do manage to retrieve the 


### PR DESCRIPTION
If the user isn't logged into the service providing access to the tool then when the launch is done we don't get a subject claim in the JWT.

This is still a valid launch and it's up to the consuming tool to decide how they want to handle these launches.