### PR TITLE
Workaround new window LTI launches.

### DIFF
--- a/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
+++ b/src/main/resources/uk/ac/ox/ctl/lti13/step-1-redirect.html
@@ -37,6 +37,13 @@
         }
         const platformOrigin = "*"; // Canvas doesn't support origin.
         let targetFrame = window.parent || window.opener
+        
+        if (targetFrame === window) {
+            // We don't have anywhere to send the message to, so we can't do anything.
+            // This seems to happen with Canvas when the LTI launch is done in a new window/tab.
+            console.log('We cannot store state so relying on cookies (which might be blocked)');
+            document.location = url;
+        }
 
         // If we don't get any response from the platform show something to the user.
         setTimeout(function() {


### PR DESCRIPTION
When launching a LTI tool in a new window directly from Canvas it will not have a window.opener set because Canvas launches the new window to it's own URL (https://canvas.instructure.com...) which then redirects to the tool. Browsers block the window.opener property if it doesn't match the domain that the new window was opened with and in this case a LTI tool will be on a different domain.

This doesn't introduce a security issue because the checking of state is done in step 3 and if it was successfully set by a cookie the LTI launch will continue without a problem, but it does remove the pause that is seen when we don't have a valid window to send our post messages to.