### PR TITLE
Allow WORKING_COOKIES on cross-site requests

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -8,10 +8,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * Checks to see if we already have a valid HTTP Session containing a token, if so we store details of the login
- * in the HTTP Session, otherwise we use store based on the state. When debugging things you can tell on the client if
- * the login was done using the session as the redirect to the tool in step 3 is done as a HTTP 302 redirect, if the 
- * check is done by the browser using LTI Storage the step 3 is a HTTP 200 response where JS does the redirect.
+ * Checks whether a valid HTTP session already contains a token. If so, we store the login details in the HTTP session;
+ * otherwise, we use state-based storage. When debugging on the client, if login uses the session then step 3 returns
+ * an HTTP 302 redirect to the tool. If login uses LTI storage in the browser, then step 3 returns HTTP 200 and
+ * JavaScript performs the redirect.
  */
 public class OptimisticAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -9,7 +9,9 @@ import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Checks to see if we already have a valid HTTP Session containing a token, if so we store details of the login
- * in the HTTP Session, otherwise we use store based on the state.
+ * in the HTTP Session, otherwise we use store based on the state. When debugging things you can tell on the client if
+ * the login was done using the session as the redirect to the tool in step 3 is done as a HTTP 302 redirect, if the 
+ * check is done by the browser using LTI Storage the step 3 is a HTTP 200 response where JS does the redirect.
  */
 public class OptimisticAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
@@ -48,6 +50,7 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
+        cookie.setAttribute("SameSite", "None");
         // Set the cookie for 1 year.
         // TODO This should be configurable.
         cookie.setMaxAge(60 * 60 * 24 * 356);

--- a/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/security/oauth2/client/lti/web/OptimisticAuthorizationRequestRepository.java
@@ -53,7 +53,7 @@ public class OptimisticAuthorizationRequestRepository implements AuthorizationRe
         cookie.setAttribute("SameSite", "None");
         // Set the cookie for 1 year.
         // TODO This should be configurable.
-        cookie.setMaxAge(60 * 60 * 24 * 356);
+        cookie.setMaxAge(60 * 60 * 24 * 365);
         response.addCookie(cookie);
         // Mark the current request as having a working session.
         request.setAttribute(ATTRIBUTE_NAME, true);

--- a/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
+++ b/src/test/java/uk/ac/ox/ctl/lti13/stateful/Lti13Step3Test.java
@@ -52,6 +52,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -202,7 +205,16 @@ public class Lti13Step3Test {
                 .thenReturn(new ResponseEntity<>(jwkSet().toString(), HttpStatus.OK));
         mockMvc.perform(post("/lti/login").param("id_token", createJWT(claims)).param("state", "state"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(cookie().exists("WORKING_COOKIES"));
+                .andExpect(cookie().exists("WORKING_COOKIES"))
+                .andExpect(result -> {
+                    Cookie cookie = result.getResponse().getCookie("WORKING_COOKIES");
+                    assertNotNull(cookie);
+                    assertEquals("true", cookie.getValue());
+                    assertEquals("/", cookie.getPath());
+                    assertTrue(cookie.getSecure());
+                    assertTrue(cookie.isHttpOnly());
+                    assertEquals("None", cookie.getAttribute("SameSite"));
+                });
     }
 
     @Test


### PR DESCRIPTION
Browsers often ignore or withhold cookies on cross-site requests unless they are marked explicitly for that use.

WORKING_COOKIES may be used in an embedded cross-site LTI launch. Marking it SameSite=None; Secure allows browsers to include it in that third-party context, where the default cookie policy would otherwise prevent it from being sent. This improves compatibility, though some browsers may still block third-party cookies.